### PR TITLE
WIP: compose: remove /etc/timezone

### DIFF
--- a/src/denzel/docker-compose.yml
+++ b/src/denzel/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - '${api_port}:8000'
     volumes:
       - '.:/opt/denzel'
-      - '/etc/timezone:/etc/timezone:ro'
       - '/etc/localtime:/etc/localtime:ro'
     environment:
       - GUNICORN_CMD_ARGS="--timeout=600"  # 10 minutes
@@ -27,7 +26,6 @@ services:
     volumes:
       - '.:/opt/denzel'
       - './logs:/opt/denzel/logs'
-      - '/etc/timezone:/etc/timezone:ro'
       - '/etc/localtime:/etc/localtime:ro'
     environment:
       - CELERY_BROKER=redis://redis:6379/0
@@ -46,7 +44,6 @@ services:
       - '${monitor_port}:5555'
     volumes:
       - '.:/opt/denzel'
-      - '/etc/timezone:/etc/timezone:ro'
       - '/etc/localtime:/etc/localtime:ro'
     entrypoint: ./entrypoints/monitor.sh
     depends_on:


### PR DESCRIPTION
`/etc/timezone` seems to be a directory on Amazon Linux.

Fixes #1

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>